### PR TITLE
Issue with CodeGenerationRoot

### DIFF
--- a/Elemental.JsonResource/build/Elemental.JsonResource.targets
+++ b/Elemental.JsonResource/build/Elemental.JsonResource.targets
@@ -27,7 +27,7 @@
 	>
 
 		<PropertyGroup>
-			<CodeGenerationRoot>$(MSBuildProjectDirectory)\$(IntermediateOutputPath)</CodeGenerationRoot>
+			<CodeGenerationRoot>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),$(IntermediateOutputPath)))</CodeGenerationRoot>
 		</PropertyGroup>
 
 		<ItemGroup>


### PR DESCRIPTION
Hey mate,

Excellent project!

I ran into an issue as my OutputPath is not relative to the MSBuildProjectDirectory, and the build would fail with an invalid directory exception.

I've updated the line in `Elemental.JsonResource.targets` to use `Path.Combine` instead.

Cheers!